### PR TITLE
Ksdfg

### DIFF
--- a/currently_watching.py
+++ b/currently_watching.py
@@ -4,7 +4,6 @@
 # This means that I already have downloaded ep. 34 and need to download ep.35
 # Please ensure that the show's name is exactly the same as it appears in HorribleSubs' schedule
 
-
 shows = {'Fruits Basket (2019)': 12,
 'Senryuu Shoujo': 12,
 'Midara na Ao-chan wa Benkyou ga Dekinai': 12,

--- a/currently_watching.py
+++ b/currently_watching.py
@@ -1,3 +1,10 @@
+# This is the list of shows you are currently watching this season
+# The syntax is "show's name": next episode to be downloaded
+# e.g. : "JoJo's Bizarre Adventure - Golden Wind": 35
+# This means that I already have downloaded ep. 34 and need to download ep.35
+# Please ensure that the show's name is exactly the same as it appears in HorribleSubs' schedule
+
+
 shows = {'Fruits Basket (2019)': 12,
 'Senryuu Shoujo': 12,
 'Midara na Ao-chan wa Benkyou ga Dekinai': 12,

--- a/horrible_downloader.py
+++ b/horrible_downloader.py
@@ -8,58 +8,84 @@ from currently_watching import shows
 import horrible_functions as hf
 from user_preferences import preferences
 
+# parse html source of horriblesubs homepage
 soup = bs(requests.get("https://horriblesubs.info/").text, features='html.parser')
 
+# list of all anime that are released today and are in your currently watching shows
 links = [i for i in soup.select('a[title = "See all releases for this show"]') if i.text in shows.keys()]
 if len(links) == 0:
-    print("Nothing to download today! T-T")
+    print("Nothing to download today T-T")
     exit(0)
 
+# open a web driver according to browser preference
 driver = hf.drivers[preferences['browser']](executable_path=preferences['driver_path'])
-driver.implicitly_wait(10)
+driver.implicitly_wait(10)  # make driver inherently wait for 10s after opening a page
 
-
+# iterate for each link
 for link in links:
-    i = 0
+
+    i = 0   # reset number of clicks - we start from number 0
+
+    print("\n" + link.text)     # print name of anime you are checking
+
+    # var that stores which episode you are trying to download
     ep = str(shows[link.text])
+    if len(ep) == 1:
+        ep = '0' + ep
+
+    # open the page in web driver
     driver.get("https://horriblesubs.info" + link.get("href"))
 
+    # scroll down a little to make elements more visible
+    pog.scroll(-20)
+
+    # enter episode number in the search bar
     driver.find_element_by_css_selector('#hs-search > input').send_keys(ep)
     pog.press('enter')
     sleep(1)
 
+    # select which episode you want to download (from search results), and view download links
     try:
         hf.episode_selector(driver, ep, preferences['browser']).click()
-    except NoSuchElementException:
-        print("New Episode of " + link.text + " has not yet released!!\n\n")
+    except NoSuchElementException:  # thrown if no results found
+        print("No Download link for required episode T-T")
         continue
 
     sleep(1)
+
+    # select which magnet link you want to open, and open it
     try:
         hf.magnet_selector(driver, ep, preferences['quality'], preferences['browser']).click()
-    except NoSuchElementException:
-        print("New Episode of " + link.text + " has not yet released!!\n\n")
+    except NoSuchElementException:  # thrown if no magnet link of required quality found
+        print("No Download link for required episode T-T")
         continue
 
+    # click on the okay button to open your torrent downloading software
     sleep(1)
     pog.click(*preferences['clicks'][i])
     i += 1
+
     sleep(1)
+
+    # define path where episode is to be downloaded
     path = preferences['download_path'] + link.text
     if not os.path.exists(path):
-        os.makedirs(path)
+        os.mkdir(path)  # if directory doesn't exist, make one
 
+    # start downloading torrent from your preferred software
     hf.torrents[preferences['torrent']](i, path)
 
-    shows[link.text] += 1
-
+    # close torrent software so focus is switched to web driver again for next anime
     sleep(1)
     pog.hotkey('alt', 'f4')
     sleep(2)
 
-driver.close()
+    # next time try to download the next episode
+    shows[link.text] += 1
 
+driver.close()  # once you have checked all animes in links, close the web driver
 
+# update the currently watching list
 f = open("currently_watching.py", "w")
 f.write("shows = " + str(shows).replace(", ", ",\n"))
 f.close()

--- a/horrible_downloader.py
+++ b/horrible_downloader.py
@@ -80,6 +80,9 @@ for link in links:
     pog.hotkey('alt', 'f4')
     sleep(2)
 
+    # give confirmation message to user on terminal
+    print("Downloading episode", ep, "now :)")
+
     # next time try to download the next episode
     shows[link.text] += 1
 

--- a/horrible_downloader.py
+++ b/horrible_downloader.py
@@ -90,5 +90,5 @@ driver.close()  # once you have checked all animes in links, close the web drive
 
 # update the currently watching list
 f = open("currently_watching.py", "w")
-f.write("shows = " + str(shows).replace(", ", ",\n"))
+f.write(hf.cw_comment + "shows = " + str(shows).replace(", ", ",\n"))
 f.close()

--- a/horrible_downloader.py
+++ b/horrible_downloader.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup as bs
 import requests
 from currently_watching import shows
 import horrible_functions as hf
-from user_preferences import preferences as pf
+from user_preferences import preferences
 
 soup = bs(requests.get("https://horriblesubs.info/").text, features='html.parser')
 
@@ -15,7 +15,7 @@ if len(links) == 0:
     print("Nothing to download today! T-T")
     exit(0)
 
-driver = hf.drivers[pf['browser']](pf['driver_path'])
+driver = hf.drivers[preferences['browser']](executable_path=preferences['driver_path'])
 driver.implicitly_wait(10)
 
 
@@ -29,23 +29,27 @@ for link in links:
     sleep(1)
 
     try:
-        hf.episode_selector(driver, ep, pf['browser']).click()
+        hf.episode_selector(driver, ep, preferences['browser']).click()
     except NoSuchElementException:
-        pog.hotkey('alt', '\t')
         print("New Episode of " + link.text + " has not yet released!!\n\n")
         continue
 
     sleep(1)
-    hf.magnet_selector(driver, ep, pf['quality'], pf['browser']).click()
+    try:
+        hf.magnet_selector(driver, ep, preferences['quality'], preferences['browser']).click()
+    except NoSuchElementException:
+        print("New Episode of " + link.text + " has not yet released!!\n\n")
+        continue
+
     sleep(1)
-    pog.click(*pf['clicks'][i])
-    i+=1
+    pog.click(*preferences['clicks'][i])
+    i += 1
     sleep(1)
-    path = pf['download_path'] + link.text
+    path = preferences['download_path'] + link.text
     if not os.path.exists(path):
         os.makedirs(path)
 
-    hf.torrents[pf['torrent']](i,path)
+    hf.torrents[preferences['torrent']](i, path)
 
     shows[link.text] += 1
 

--- a/horrible_functions.py
+++ b/horrible_functions.py
@@ -1,3 +1,6 @@
+# This file basically has all the functions and variables that allow our system to be modular
+# Which functions / variables are used depends on the user's preference settings
+
 from user_preferences import preferences
 from selenium import webdriver as wbd
 from time import sleep
@@ -56,3 +59,9 @@ torrents = {
     'utorrent': utorrent_download,
     'qbittorrent': qbittorrent_download
 }
+
+# the comment you have to write to currently watching.... this was dumb
+cw_comment = '# This is the list of shows you are currently watching this season\n# The syntax is "show\'s name": ' \
+             'next episode to be downloaded\n# e.g. : "JoJo\'s Bizarre Adventure - Golden Wind": 35\n# This means ' \
+             'that I already have downloaded ep. 34 and need to download ep.35\n# Please ensure that the show\'s name ' \
+             'is exactly the same as it appears in HorribleSubs\' schedule\n\n'

--- a/horrible_functions.py
+++ b/horrible_functions.py
@@ -1,7 +1,7 @@
 from selenium import webdriver as wbd
 from time import sleep
 import pyautogui as pog
-from user_preferences import preferences as pf
+from user_preferences import preferences
 
 
 drivers = {
@@ -32,12 +32,12 @@ def utorrent_download(path):
     pog.press('enter')
 
 
-def qbittorrent_download(i,path):
+def qbittorrent_download(i, path):
     sleep(3)
-    pog.click(*pf['clicks'][i])
+    pog.click(*preferences['clicks'][i])
     i += 1
     sleep(2)
-    pog.click(*pf['clicks'][i])
+    pog.click(*preferences['clicks'][i])
     i += 1
     pog.typewrite(path)     # enter path where you want to store the downloaded episode
     pog.press('enter')
@@ -45,6 +45,7 @@ def qbittorrent_download(i,path):
     pog.press('enter')
     pog.press('enter')
     sleep(2)
+
 
 torrents = {
     'utorrent': utorrent_download,

--- a/horrible_functions.py
+++ b/horrible_functions.py
@@ -1,15 +1,16 @@
+from user_preferences import preferences
 from selenium import webdriver as wbd
 from time import sleep
 import pyautogui as pog
-from user_preferences import preferences
 
-
+# Dictionary of web drivers according to browser
 drivers = {
     'firefox': wbd.Firefox,
     'chrome': wbd.Chrome
 }
 
 
+# A function that returns the element which, when clicked, brings links of episode to be downloaded in view
 def episode_selector(webdriver, ep, browser):
     if browser == 'firefox':
         return webdriver.find_element_by_css_selector(r'.rls-label')
@@ -17,6 +18,7 @@ def episode_selector(webdriver, ep, browser):
         return webdriver.find_element_by_xpath('//*[@id="' + ep + '"]/a')
 
 
+# A funtion that returns the element which, when clicked, opens magnet link
 def magnet_selector(webdriver, ep, quality, browser):
     if browser == 'firefox':
         return webdriver.find_element_by_css_selector(r'#\3' + ep[0] + ' ' + ep[1:] + '-' + quality + '> span:nth-child(2) > ''a:nth-child(1)')
@@ -24,14 +26,16 @@ def magnet_selector(webdriver, ep, quality, browser):
         return webdriver.find_element_by_xpath('//*[@id="' + ep + '-1080p"]/span[2]/a')
 
 
+# Function for when magnet link is opened in utorrent
 def utorrent_download(path):
     sleep(3)
-    pog.typewrite(path)  # enter path where you want to store the downloaded episode
+    pog.typewrite(path)     # enter path where you want to store the downloaded episode
     pog.press('enter')
     sleep(5)
     pog.press('enter')
 
 
+# Function for when magnet link is opened in qbittorrent
 def qbittorrent_download(i, path):
     sleep(3)
     pog.click(*preferences['clicks'][i])
@@ -47,6 +51,7 @@ def qbittorrent_download(i, path):
     sleep(2)
 
 
+# dictionary to decide which function should be called to start torrent download
 torrents = {
     'utorrent': utorrent_download,
     'qbittorrent': qbittorrent_download


### PR DESCRIPTION
- Added comments - Please check if anything is confusing

- I need to state the argument as executable_path in line 21 of horrible_downloader.py (constructing web driver object) or it gives me an invalid directory error. Better safe than sorry.

- Removed the alt+tab in the no such element catch. It was bringing focus to pycharm when no episode needs to be downloaded - if there is an episode to be downloaded in the next anime then the magnet link open thingy will be open in background while our mouse will just be clicking on the pycharm run screen.

- Added try catch to magnet selector - this is because sometimes horriblesubs uploads magnet links of just lower resoultion videos first, the 1080p link comes later. Sometimes there is no magnet link up for a while - it's just direct download links. In these cases our downloader will crash since the episode selector will be found, but not the magnet selector.

- Changed the output format a little - It first prints name of show on std out, then if it does download it prints "Downloading episode xx now :)" (line 84) else prints "No Download link for required episode T-T" (lines 51 & 60)

- I commented the currently watching file, but then realized I was overwriting the comment each time :P So I stored the entire comment as a string in variable cw_comment in horrible_functions.py (line 64) and wrote that to currently_watching.py as well along with the dictionary of shows in horrible_downloader.py (line 93)